### PR TITLE
Update musicObj.py

### DIFF
--- a/cloudmusic/musicObj.py
+++ b/cloudmusic/musicObj.py
@@ -106,7 +106,13 @@ class Music:
     # 获取歌词
     def getLyrics(self):
         lrc =  api.Api().get_lyrics(dict(ID = self.id))
-        lyric = lrc["lrc"]["lyric"]
-        tlyric = lrc["tlyric"]["lyric"]
+        lyric = ""
+        tlyric = ""
+        
+        if "lrc" in lrc:
+            lyric = lrc["lrc"]["lyric"]
+            if "lyric" in lrc["tlyric"]:
+                tlyric = lrc["tlyric"]["lyric"]
+
         return [lyric, tlyric]
 


### PR DESCRIPTION
在调试时发现歌词不存在或歌词翻译不存在时会发生字典的键错误，修复之后的结果为如果不存在歌词或者歌词的翻译则直接返回空字符串。